### PR TITLE
Feature/zookeeper probes

### DIFF
--- a/incubator/zookeeper/Chart.yaml
+++ b/incubator/zookeeper/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 name: zookeeper
 home: https://zookeeper.apache.org/
-version: 2.1.4
+version: 2.1.5
 appVersion: 3.5.5
 kubeVersion: "^1.10.0-0"
 description: Centralized service for maintaining configuration information, naming,

--- a/incubator/zookeeper/templates/statefulset.yaml
+++ b/incubator/zookeeper/templates/statefulset.yaml
@@ -67,21 +67,21 @@ spec:
               command:
                 - sh
                 - /config-scripts/ok
-            initialDelaySeconds: 20
-            periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 2
-            successThreshold: 1
+            initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.livenessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.livenessProbe.failureThreshold }}
+            successThreshold: {{ .Values.livenessProbe.successThreshold }}
           readinessProbe:
             exec:
               command:
                 - sh
                 - /config-scripts/ready
-            initialDelaySeconds: 20
-            periodSeconds: 30
-            timeoutSeconds: 5
-            failureThreshold: 2
-            successThreshold: 1
+            initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
+            periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
+            timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
+            failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
+            successThreshold: {{ .Values.readinessProbe.successThreshold }}
           env:
             - name: ZK_REPLICAS
               value: {{ .Values.replicaCount | quote }}

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -129,6 +129,20 @@ persistence:
   accessMode: ReadWriteOnce
   size: 5Gi
 
+readinessProbe:
+  initialDelaySeconds: 20
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 2
+  successThreshold: 1
+
+readinessProbe:
+  initialDelaySeconds: 20
+  periodSeconds: 30
+  timeoutSeconds: 5
+  failureThreshold: 2
+  successThreshold: 1
+
 ## Exporters query apps for metrics and make those metrics available for
 ## Prometheus to scrape.
 exporters:

--- a/incubator/zookeeper/values.yaml
+++ b/incubator/zookeeper/values.yaml
@@ -129,7 +129,7 @@ persistence:
   accessMode: ReadWriteOnce
   size: 5Gi
 
-readinessProbe:
+livenessProbe:
   initialDelaySeconds: 20
   periodSeconds: 30
   timeoutSeconds: 5


### PR DESCRIPTION
The timing for probes in zookeeper incubator charts is hard coded. This
can cause problems when for example the initialDelaySeconds is not
sufficient for a particular cloud.